### PR TITLE
fix: change deprecated runtime to nodejs12.x

### DIFF
--- a/lustre/templates/04-linux-instance.yaml
+++ b/lustre/templates/04-linux-instance.yaml
@@ -124,7 +124,7 @@ Resources:
         S3Bucket: !Sub solution-references-${AWS::Region}
         S3Key: fsx/amilookup-lin.zip
       Handler: amilookup-lin.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 30
       Role: !GetAtt LambdaExecutionRole.Arn
   AmiInfo:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There was a reference to the nodejs8.10 runtime for AWS Lambda, which is deprecated since March 2020. I checked the source code for the Lambda function and this change should not cause issues there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
